### PR TITLE
Addtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
               with:
                 go-version: '1.20'
             
-            - name: Force Failure
-              run: (exit 1)
+            - name: check Go Version
+              run: go version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+
+on:
+    pull_request:
+        branches: [main]
+    
+jobs:
+    tests:
+        name: Tests
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@v4
+            
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                go-version: '1.20'
+            
+            - name: Force Failure
+              run: (exit 1)


### PR DESCRIPTION
fixes test workflow to not exit with failure and instead print the installed go version.